### PR TITLE
3Legged OAuth feature using the RC-2.0.0 Pre Release candidate to cache the tokens

### DIFF
--- a/php/callback.php
+++ b/php/callback.php
@@ -10,56 +10,36 @@ session_start();
 $dotenv = new Dotenv\Dotenv(getcwd());
 $dotenv -> load();
 
-function processCode()
+// retrieve the sdk from session object
+$rcsdk = $_SESSION['sdk'];
+
+function processCode($rcsdk)
 {
-    if(!isset($_GET['code'])) {
+
+
+    // $rcsdk = $_SESSION['sdk'];
+    
+    if(!isset($_GET['code'])) 
+    {
         return;
     }
-    $authCode = $_GET['code'];
 
-    $tokenUrl = $_ENV['RC_Server'] . '/restapi/oauth/token';
-    
-    $values = array(
-        'grant_type'   => 'authorization_code',
-        'code'         => $authCode,
-        'redirect_uri' => $_ENV['RC_Redirect_Url']
-    );
+    $qs = $rcsdk->platform()->parseAuthRedirectUrl($_SERVER['QUERY_STRING']);
+    $qs["redirectUri"] = $_ENV['RC_Redirect_Url'];
 
-    $apiKey = base64_encode($_ENV['RC_AppKey'] . ':' . $_ENV['RC_AppSecret']);
+    $apiResponse = $rcsdk->platform()->login($qs);
 
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $tokenUrl);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-      'Authorization: Basic' . $apiKey,
-      'Accept: application/json',
-      'Content-Type: application/x-www-form-urlencoded'
-    ));
-    curl_setopt($ch, CURLOPT_POST, count($values));
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($values));
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_VERBOSE, 1);
-    curl_setopt($ch, CURLOPT_HEADER, 1);
+    $body = json_encode(json_decode($apiResponse->text(), true), JSON_PRETTY_PRINT);
 
-    $response = curl_exec($ch);
-
-    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-    $body = substr($response, $headerSize);
-    
-    //close connection
-    curl_close($ch);
-
-    $body = json_encode(json_decode($body, true), JSON_PRETTY_PRINT);
-
-    //Store the response in PHP Session Object
-    $_SESSION['response'] = $body;
-
-    return $body;
+    $_SESSION['response'] = $apiResponse->text();
 
 }
 
-$result= processCode();
+$result= processCode($rcsdk);
 
 session_write_close();
 
 ?>
+
+
 

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "ringcentral/ringcentral-php": "^1.1",
+        "ringcentral/ringcentral-php": "2.0.0-rc1",
         "vlucas/phpdotenv": "^2.2"
     }
 }

--- a/php/index.php
+++ b/php/index.php
@@ -18,22 +18,20 @@ $rcsdk = new SDK($_ENV['RC_AppKey'],$_ENV['RC_AppSecret'],$_ENV['RC_Server'], 'O
 
 $platform = $rcsdk->platform();
 
-$url = $platform->createUrl('/restapi/oauth/authorize' . '?' .
-	http_build_query(
-        array (
-            'response_type' => 'code',
-            'redirect_uri'  => $_ENV['RC_Redirect_Url'],
-            'client_id'     => $_ENV['RC_AppKey'],
-            'state'         => $_ENV['RC_State'],
-            'brand_id '     => '',
-            'display'       => '',  
-            'prompt'        => ''
-        )
-    ),
-    array (
-        'addServer' => true
-    )
-);
+
+// using the authUrl to call the platform function
+$url = $platform
+       ->authUrl(array(
+                    'redirectUri' => isset($_ENV['RC_Redirect_Url']) ? $_ENV['RC_Redirect_Url'] : '',
+                    'state'       => 'myState',
+                    'brandId'     => '',
+                    'display'     => '',
+                    'prompt'      => ''
+                ));
+
+//Store the sdk instance in PHP Session Object
+$_SESSION['sdk'] = $rcsdk; 
+$_SESSION['url'] = $url;      
 
 ?>
 <!DOCTYPE html>
@@ -71,7 +69,7 @@ $url = $platform->createUrl('/restapi/oauth/authorize' . '?' .
 		                }
 		            } catch(e) {
 		                console.log(e);
-		                //win.close();
+		                // win.close();
 		            }
         			}, 100);
 			        


### PR DESCRIPTION
Changes included are : 

- `authUrl` method of the platform object lets you create the URL needed for the redirect
- `parseAuthRedirectUrl` method of the platform to parse the redirectUri for the Authorization Code

Once authorized using the `platform->login()` , the platform object stores the tokens in the `auth` object.

Note : We are using the `2.0.0-rc1` version of [ringcentral-php](https://github.com/ringcentral/ringcentral-php/tree/2.0.0-rc1) SDK at the moment. 
